### PR TITLE
Add project ordering test

### DIFF
--- a/tests/test_email_format.py
+++ b/tests/test_email_format.py
@@ -72,3 +72,35 @@ def test_milestones_and_tasks_included():
     assert 'Milestone1' in html
     assert 'Task1' in html
 
+
+def test_projects_sorted_alphabetically():
+    tasks = [
+        (
+            'Task B',
+            datetime.date(2023, 9, 10),
+            'Alice',
+            'http://example.com/b',
+            'Project B',
+        ),
+        (
+            'Task A',
+            datetime.date(2023, 9, 10),
+            'Alice',
+            'http://example.com/a',
+            'Project A',
+        ),
+        (
+            'Task C',
+            datetime.date(2023, 9, 10),
+            'Alice',
+            'http://example.com/c',
+            'Project C',
+        ),
+    ]
+    milestones = []
+    html = module.build_email_html(tasks, milestones)
+    idx_a = html.find('<h1>Project A Tasks</h1>')
+    idx_b = html.find('<h1>Project B Tasks</h1>')
+    idx_c = html.find('<h1>Project C Tasks</h1>')
+    assert idx_a < idx_b < idx_c
+


### PR DESCRIPTION
## Summary
- extend email format tests with check for alphabetical project ordering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68841c437354833195881da0e313c56f