### PR TITLE
Add GitHub commit preview

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,8 @@ WEB_TOKEN_URI=https://oauth2.googleapis.com/token
 FROM_EMAIL=from@example.com
 TO_EMAIL=recipient1@example.com,recipient2@example.com
 
+# GitHub repository for showing recent commits
+GITHUB_REPO=owner/repo
+# Optional GitHub token
+GITHUB_TOKEN=
+

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Make sure your `.env` file is in the project directory.
 - `WEB_CLIENT_SECRET` – Gmail OAuth client secret.
 - `WEB_REFRESH_TOKEN` – refresh token for OAuth.
 - `WEB_TOKEN_URI` – token URI for OAuth refresh requests.
+- `GITHUB_REPO` – repository in `owner/repo` form for showing recent commits.
+- `GITHUB_TOKEN` – optional token for authenticated GitHub API requests.
 
 ## Running Tests
 

--- a/tests/test_fetch_commits.py
+++ b/tests/test_fetch_commits.py
@@ -1,0 +1,40 @@
+import importlib.util
+import os
+from unittest.mock import patch, Mock
+
+# Import module
+spec = importlib.util.spec_from_file_location(
+    'asana_notification', os.path.join(os.path.dirname(__file__), '..', 'asana-notification.py')
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+def test_fetch_commits_success():
+    mock_resp = Mock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = [
+        {
+            'sha': 'abcdef1234567890',
+            'commit': {
+                'author': {'name': 'Alice'},
+                'message': 'Initial commit\n\nFull message'
+            }
+        }
+    ]
+    with patch('requests.get', return_value=mock_resp) as p:
+        os.environ['GITHUB_REPO'] = 'owner/repo'
+        commits = module.fetch_commits()
+        assert commits == ['Alice: Initial commit (abcdef1)']
+        p.assert_called_once()
+
+
+def test_fetch_commits_failure():
+    mock_resp = Mock()
+    mock_resp.status_code = 500
+    mock_resp.text = 'error'
+    with patch('requests.get', return_value=mock_resp):
+        os.environ['GITHUB_REPO'] = 'owner/repo'
+        commits = module.fetch_commits()
+        assert commits is None
+


### PR DESCRIPTION
## Summary
- fetch latest commits from a configured GitHub repository
- show commit list on the home page
- document new `GITHUB_REPO` and `GITHUB_TOKEN` variables
- test commit fetching logic

## Testing
- `pip install -r requirements.txt`
- `pip install pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6884247284fc8331b2f5c242341725c3