### PR TITLE
Add status link to landing page

### DIFF
--- a/asana-notification.py
+++ b/asana-notification.py
@@ -344,6 +344,7 @@ def serve_http(port=8080, bind=""):
                 <pre>python asana-notification.py --run-now</pre>
                 <p>You may also start it with Docker:</p>
                 <pre>docker-compose up</pre>
+                <p>See current progress at <a href='/status'>/status</a>.</p>
                 </div>
                 </body>
                 </html>


### PR DESCRIPTION
## Summary
- expose a link to `/status` on the landing page for progress

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688424770cbc8331b808c615c6a9e700