### PR TITLE
Add auto changelog hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,5 @@ All notable changes to this project will be documented in this file.
 - Logging for fetching data and sending emails.
 - HTTP endpoint `/run` to trigger the script manually.
 
+## [Unreleased]
+- 2025-07-25: Merge pull request #14 from ammargrowme/codex/add-commit-fetching-functionality

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ docker-compose up
 
 Make sure your `.env` file is in the project directory.
 
+## Automatic Changelog Updates
+
+Install the Git hook to keep `CHANGELOG.md` and the README's recent change
+section in sync with your commits:
+
+```bash
+./hooks/install.sh
+```
+
+Every time you commit, the hook will record the commit message and date.
+
 ## Command-line Options
 
 - `--max-projects NUM` – limit the number of projects processed.
@@ -75,3 +86,5 @@ pytest
 
 This project is provided as-is under the MIT License.
 
+## Recent Changes
+- 2025-07-25: Merge pull request #14 from ammargrowme/codex/add-commit-fetching-functionality

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Install the git post-commit hook
+HOOK_DIR="$(git rev-parse --git-dir)/hooks"
+mkdir -p "$HOOK_DIR"
+cp hooks/post-commit "$HOOK_DIR/post-commit"
+chmod +x "$HOOK_DIR/post-commit"
+echo "post-commit hook installed to $HOOK_DIR/post-commit"

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Update documentation based on the latest commit
+python3 scripts/update_docs.py

--- a/scripts/update_docs.py
+++ b/scripts/update_docs.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Update CHANGELOG.md and README.md based on the latest commit."""
+from pathlib import Path
+import subprocess
+import datetime
+
+
+def get_latest_commit_info():
+    message = subprocess.check_output(['git', 'log', '-1', '--pretty=%B']).decode().strip()
+    first_line = message.splitlines()[0]
+    date = subprocess.check_output(['git', 'log', '-1', '--pretty=%ad', '--date=short']).decode().strip()
+    return first_line, date
+
+
+def update_changelog(commit_msg, commit_date):
+    path = Path('CHANGELOG.md')
+    if not path.exists():
+        return
+    text = path.read_text().rstrip() + '\n'
+    header = '## [Unreleased]'
+    entry = f"- {commit_date}: {commit_msg}"
+    if entry in text:
+        return
+    if header not in text:
+        text += f"\n{header}\n"
+    lines = text.splitlines()
+    if header not in lines:
+        lines.append(header)
+    idx = lines.index(header) + 1
+    lines.insert(idx, entry)
+    path.write_text('\n'.join(lines) + '\n')
+
+
+def update_readme(commit_msg, commit_date):
+    path = Path('README.md')
+    if not path.exists():
+        return
+    text = path.read_text().rstrip() + '\n'
+    header = '## Recent Changes'
+    entry = f"- {commit_date}: {commit_msg}"
+    lines = text.splitlines()
+    if header not in lines:
+        lines.append('')
+        lines.append(header)
+        lines.append(entry)
+    else:
+        idx = lines.index(header) + 1
+        if entry in lines:
+            return
+        lines.insert(idx, entry)
+    path.write_text('\n'.join(lines) + '\n')
+
+
+def main():
+    commit_msg, commit_date = get_latest_commit_info()
+    update_changelog(commit_msg, commit_date)
+    update_readme(commit_msg, commit_date)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- automate CHANGELOG and README updates with a post-commit hook
- document how to install the hook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6884246661388331935377943c744360