### PR TITLE
Fix logs display on run page

### DIFF
--- a/asana-notification.py
+++ b/asana-notification.py
@@ -478,7 +478,9 @@ def serve_http(port=8080, bind=""):
                     document.getElementById('error').textContent = data.error ? 'Error: ' + data.error : '';
                   }});
                   fetch('/logs', {{cache: 'no-store'}}).then(r => r.json()).then(data => {{
-                    document.getElementById('logs').textContent = data.logs.join('\n');
+                    # Use two backslashes so the rendered JavaScript contains
+                    # a literal "\n" sequence instead of an actual newline.
+                    document.getElementById('logs').textContent = data.logs.join('\\n');
                     var logEl = document.getElementById('logs');
                     logEl.scrollTop = logEl.scrollHeight;
                   }});


### PR DESCRIPTION
## Summary
- ensure newline escape is preserved for logs output on the progress page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68843fbe66e883319fcffd5550008244